### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.owners/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.owners/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.owners.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.owners/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.owners.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.owners)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.owners.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.owners)
 
 ## Overview
 
@@ -119,7 +119,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Owners` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Owners` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -120,7 +120,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Owners` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Owners` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 


### PR DESCRIPTION
## Purpose

Fixes documentation issues in this connector's READMEs (top-level and `ballerina/`) identified during the HubSpot connector documentation audit.

Changes:
- Replace `Hubspot` with `HubSpot` in brand-name positions (kept package names, URLs, and code identifiers untouched).
- Fix the encoding in the GitHub Issues badge target URL: `…/labels/module%hubspot.crm.owners` -> `…/labels/module%2Fhubspot.crm.owners` (the literal `%` was a half-encoded `%2F` slash, which broke the link).

Refs ballerina-platform/ballerina-library#8823

## Examples

N/A - documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog - N/A, documentation-only change
- [ ] Added tests - N/A, documentation-only change
- [ ] Updated the spec - N/A, documentation-only change
- [ ] Checked native-image compatibility - N/A, documentation-only change